### PR TITLE
Add color_hsb() function to allow precise HSB/HSV setting

### DIFF
--- a/colorwheel.js
+++ b/colorwheel.js
@@ -13,6 +13,7 @@
 Raphael.colorwheel = function(target, color_wheel_size, no_segments){
   var canvas,
       current_color,
+      current_color_hsb,
       size,
       segments = no_segments || 60,
       bs_square = {},
@@ -64,7 +65,8 @@ Raphael.colorwheel = function(target, color_wheel_size, no_segments){
       input: input,
       onchange: onchange,
       ondrag : ondrag,
-      color : public_set_color
+      color : public_set_color,
+      color_hsb : public_set_color_hsb
     };
   }
 
@@ -181,16 +183,39 @@ Raphael.colorwheel = function(target, color_wheel_size, no_segments){
   }
 
   function public_set_color(value){
-    var ret = set_color(value);
+    var ret = set_color(value, false);
     update_color(false);
     return ret;
   }
 
-  function set_color(value){
-    if(value === undefined){ return current_color; }
+  function public_set_color_hsb(hsb){
+    var ret = set_color(hsb, true);
+    update_color(false);
+    return ret;
+  }
 
-    var temp = canvas.rect(1,1,1,1).attr({fill:value}),
-        hsb = canvas.raphael.rgb2hsb(temp.attr("fill"));
+  function set_color(value, is_hsb){
+    if(value === undefined){
+        if(is_hsb){
+            return current_color_hsb;
+        } else {
+            return current_color;
+        }
+    }
+
+    var hsb, hex;
+    if(is_hsb){
+        hsb = value;
+        // Allow v (value) instead of b (brightness), as v is sometimes
+        // used by Raphael.
+        if(hsb.b === undefined){ hsb.b = hsb.v; }
+        var rgb = canvas.raphael.hsb2rgb(hsb.h, hsb.s, hsb.v);
+        hex = rgb.hex;
+    } else {
+        hex = value;
+        hsb = canvas.raphael.rgb2hsb(hex);
+    }
+    var temp = canvas.rect(1,1,1,1).attr({fill:hex});
 
     set_bs_cursor(
       (0-sdim.l/2) + (sdim.l*hsb.s),
@@ -210,6 +235,7 @@ Raphael.colorwheel = function(target, color_wheel_size, no_segments){
           h: hue()
         };
 
+    current_color_hsb = hsb;
     current_color = Raphael.hsb2rgb(hsb.h, hsb.s,hsb.b);
 
     if(input_target){

--- a/index.html
+++ b/index.html
@@ -154,6 +154,16 @@
         <b>cw.color(hex_value)</b> <span class="returns">&rArr; cw</span>
         <div>Set the current color via a hex value</div>
         </div>
+
+        <div class="method">
+        <b>cw.color_hsb()</b> <span class="returns">&rArr; Raphael color object</span>
+        <div>Get the current color as HSB object</div>
+        </div>
+
+        <div class="method">
+        <b>cw.color_hsb(hsb_object)</b> <span class="returns">&rArr; cw</span>
+        <div>Set the current color via a Raphael h, s, b object</div>
+        </div>
       </div>
 
       <div id="input_example" class="example">


### PR DESCRIPTION
I have a page where I'm programatically running color() to update the color wheel based on HSB values.  But converting them to hex first means I lose resolution (e.g. a saturation of 0 always results in red on the hue wheel).  This merge extends the functionality by adding color_hsb(), which lets you update the wheel with a precise HSB object, or get the current HSB value.  Everything should be backwards compatible with the existing color() function.
