### PR TITLE
Less strict dependency on RaphaelJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "colorwheel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "J. Weir <john@famedriver.com>",
   "main": "colorwheel.js",
   "contributors": [
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "jquery": ">= 1.4.1",
-    "raphael": ">= 2.1.0"
+    "raphael": "2.0.0 - 2.1.4"
   },
   "devDependencies": {
     "qunit": ">= 1.14"


### PR DESCRIPTION
Currently, raphael is requried to be newer than 2.1.0. colorwheel, however, also works with 2.0.1 (see https://github.com/jweir/colorwheel/pull/14). I assume that it also works with raphael 2.0.0.

I am aware of https://github.com/jweir/colorwheel/issues/25 and https://github.com/jweir/colorwheel/issues/18. #18 does not seem to be a show stopper, but #25 is. Thus I set the maximum version to 2.1.4.

Would it be possible to include this update and release a version 1.0.1?
